### PR TITLE
Allow SMB2

### DIFF
--- a/smb.conf
+++ b/smb.conf
@@ -3,7 +3,6 @@
    dns proxy = no
    log file = /var/log/samba/%m.log
    max log size = 1000
-   client max protocol = NT1
    server role = standalone server
    passdb backend = tdbsam
    obey pam restrictions = yes


### PR DESCRIPTION
smb.conf in this package contains
client_max_protocol = NT1
This forces connections with an old version of the protocol, now disabled by default on many distros and Windows 10
It's also much slower than smb2, so should probably be removed?